### PR TITLE
Correct translation of syslog-ng driver `system()` on Docker

### DIFF
--- a/image/services/syslog-ng/syslog-ng.conf
+++ b/image/services/syslog-ng/syslog-ng.conf
@@ -18,7 +18,7 @@ options { chain_hostnames(off); flush_lines(0); use_dns(no); use_fqdn(no);
 # Logs may come from unix stream, but not from another machine.
 #
 source s_src {
-       unix-stream("/dev/log");
+       unix-dgram("/dev/log");
        internal();
 };
 


### PR DESCRIPTION
Porting of https://github.com/phusion/baseimage-docker/pull/382 from upstream.

Any plans to merge the fork back upstream? Upstream appears more lively recently.